### PR TITLE
Update .dir-locals.el

### DIFF
--- a/resources/practicalli/minimal/root/.dir-locals.el
+++ b/resources/practicalli/minimal/root/.dir-locals.el
@@ -1,2 +1,2 @@
 ((clojure-mode . ((cider-preferred-build-tool . clojure-cli)
-                  (cider-clojure-cli-aliases . ":build:test/env:dev/reloaded"))))
+                  (cider-clojure-cli-aliases . ":test/env:dev/reloaded"))))


### PR DESCRIPTION
When attempting to use a CIDER REPL with a newly created project from this template, the classpath was not set correctly. Rather than including the `/src` and `/resources` paths, only the project root was on the classpath. I realized that the inclusion of this `:build` alias via `.dir-locals.el` was causing the `:paths` to be replaced by `.` (as specified in the `:build` alias). This was surprising for me, and I think it may surprise others as well, as I wasn't able to `(require '[...])` namespaces in the usual way after the REPL started.

📓 Description

# _Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

# Resolve #
# Refer #

:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] New feature
- [ ] Deprecate feature
- [ ] Development workflow
- [ ] Documentation
- [ ] Continuous integration workflow

:beetle How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
